### PR TITLE
Implementación de  Sequential File con índice disperso y área auxiliaSequential file

### DIFF
--- a/src/indices/sequentialfile/sequentialfile.py
+++ b/src/indices/sequentialfile/sequentialfile.py
@@ -1,0 +1,123 @@
+from bisect import bisect_left, bisect_right
+from typing import Any, List, Tuple
+
+class Record:
+    def __init__(self, key: Any, value: Any):
+        self.key = key
+        self.value = value
+
+class SequentialFile:
+    """ en main están las llaves ordenadas, en aux no ordenado add = O(1) """
+    def __init__(self, rebuild_threshold: int = 64, index_block_size: int = 128):
+        self.main: List[Record] = []
+        self.aux:  List[Record] = []
+        self.rebuild_threshold = rebuild_threshold
+        self.index_block_size = index_block_size
+        self.sparse_index: List[Tuple[Any, int]] = []
+
+    # índice disperso (nos ayudara para busquedas rapidas)
+    def _build_sparse_index(self) -> None:
+        self.sparse_index.clear()
+        if not self.main:
+            return
+        for i in range(0, len(self.main), self.index_block_size):
+            self.sparse_index.append((self.main[i].key, i))
+
+    def _block_start_for(self, key: Any) -> int:
+        """ salta al posible bloque segun el indice disperso """
+        if not self.sparse_index:
+            return 0
+        keys = [k for (k, _) in self.sparse_index]
+        pos = bisect_right(keys, key) - 1
+        return self.sparse_index[pos][1] if pos >= 0 else 0
+
+    # funciones para hacer el merge y corroborar
+    def _merge_rebuild(self) -> None:
+        """ fusiona main y aux, ordena por key y regenera índice """
+        if not self.aux:
+            return
+        aux_sorted = sorted(self.aux, key=lambda r: r.key)
+        merged: List[Record] = []
+        i = j = 0
+        while i < len(self.main) and j < len(aux_sorted):
+            if self.main[i].key <= aux_sorted[j].key:
+                merged.append(self.main[i]); i += 1
+            else:
+                merged.append(aux_sorted[j]); j += 1
+        if i < len(self.main): merged.extend(self.main[i:])
+        if j < len(aux_sorted): merged.extend(aux_sorted[j:])
+        self.main = merged
+        self.aux.clear()
+        self._build_sparse_index()
+
+    def _check_rebuild(self) -> None:
+        """ su función es ver si ya se llego al limite """
+        if len(self.aux) >= self.rebuild_threshold:
+            self._merge_rebuild()
+
+    # estas dos funciones es para la busqueda binaria, derecha y izquierda
+    def _left_binary(self, key: Any) -> int:
+        if not self.main:
+            return 0
+        start = self._block_start_for(key)
+        keys = [r.key for r in self.main[start:]]
+        return start + bisect_left(keys, key)
+
+    def _right_binary(self, key: Any) -> int:
+        if not self.main:
+            return 0
+        start = self._block_start_for(key)
+        keys = [r.key for r in self.main[start:]]
+        return start + bisect_right(keys, key)
+
+    # funciones principales
+    def add(self, record: Record) -> None:
+        """ inserta en aux y cehca si estamos en el limite """
+        self.aux.append(record)
+        self._check_rebuild()
+
+    def search(self, key: Any) -> List[Record]:
+        """ devuelve todos los elementos con la llave, por eso usamos una lista """
+        out: List[Record] = []
+        if self.main:
+            lo = self._left_binary(key)
+            hi = self._right_binary(key)
+            if lo < hi:
+                out.extend(self.main[lo:hi])
+        if self.aux:
+            # aux es chica es pequeña = 64 así que aplicamos O(n)
+            out.extend([r for r in self.aux if r.key == key])
+        return out
+
+    def range_search(self, start_key: Any, end_key: Any) -> List[Record]:
+        """ devuelve registros que este dentro del rango start y end key """
+        out: List[Record] = []
+        if self.main:
+            lo = self._left_binary(start_key)
+            hi = self._right_binary(end_key)
+            if lo < hi:
+                out.extend(self.main[lo:hi])
+        if self.aux:
+            out.extend([r for r in self.aux if start_key <= r.key <= end_key])
+        # ordena por key
+        out.sort(key=lambda r: r.key)
+        return out
+
+    def remove(self, key: Any) -> bool:
+        """ borra todos los registros con esa key en main y aux"""
+        removed = False
+        if self.main:
+            lo = self._left_binary(key)
+            hi = self._right_binary(key)
+            if lo < hi:
+                del self.main[lo:hi]
+                removed = True
+        if self.aux:
+            new_aux = [r for r in self.aux if r.key != key]
+            if len(new_aux) != len(self.aux):
+                self.aux = new_aux
+                removed = True
+        # si hubo muchas inserciones recientes, igual se fusionará por umbral más adelante
+        # reconstruimos índice por si la ventana de bloques cambió
+        self._build_sparse_index()
+        return removed

--- a/src/indices/sequentialfile/sequentialfile.py
+++ b/src/indices/sequentialfile/sequentialfile.py
@@ -60,6 +60,9 @@ class SequentialFile:
         if not self.main:
             return 0
         start = self._block_start_for(key)
+        while start > 0 and self.main[start - 1].key == key:
+            start = max(0, start - self.index_block_size)
+
         keys = [r.key for r in self.main[start:]]
         return start + bisect_left(keys, key)
 

--- a/src/indices/sequentialfile/sequentialfileindex.py
+++ b/src/indices/sequentialfile/sequentialfileindex.py
@@ -1,0 +1,18 @@
+from typing import Any, List
+from .sequentialfile import SequentialFile, Record
+
+class SequentialFileIndex:
+    def __init__(self, rebuild_threshold: int = 64, index_block_size: int = 128):
+        self.file = SequentialFile(rebuild_threshold, index_block_size)
+
+    def add_record(self, key: Any, value: Any = None) -> None:
+        self.file.add(Record(key, value))
+
+    def search(self, key: Any) -> List[Record]:
+        return self.file.search(key)
+
+    def range_search(self, start_key: Any, end_key: Any) -> List[Record]:
+        return self.file.range_search(start_key, end_key)
+
+    def remove_record(self, key: Any) -> bool:
+        return self.file.remove(key)

--- a/tests/test_sequentialfile.py
+++ b/tests/test_sequentialfile.py
@@ -1,0 +1,188 @@
+# tests/test_sequentialfile.py
+import unittest
+import random
+
+# Intenta varias rutas de import según tu estructura real
+try:
+    from src.indices.sequentialfile.sequentialfile_min import SequentialFile, Record
+    from src.indices.sequentialfile.sequentialfileindex_min import SequentialFileIndex
+except ImportError:
+    try:
+        from src.indices.sequentialfile.sequentialfile import SequentialFile, Record
+        from src.indices.sequentialfile.sequentialfileindex import SequentialFileIndex
+    except ImportError:
+        # fallback si lo corres local sin paquete
+        from sequentialfile_min import SequentialFile, Record
+        from sequentialfileindex_min import SequentialFileIndex
+
+
+class TestSequentialFileCore(unittest.TestCase):
+    def setUp(self):
+        # Umbral pequeño para forzar rebuilds durante las pruebas
+        self.sf = SequentialFile(rebuild_threshold=3, index_block_size=2)
+
+    def test_basic_insert_search(self):
+        self.sf.add(Record(10, "v10"))
+        self.sf.add(Record(5, "v5"))
+        res10 = self.sf.search(10)
+        self.assertEqual(len(res10), 1)
+        self.assertEqual(res10[0].key, 10)
+        self.assertEqual(res10[0].value, "v10")
+        self.assertEqual(self.sf.search(99), [])
+
+    def test_rebuild_threshold_merge(self):
+        # 3 inserts en aux disparan rebuild
+        self.sf.add(Record(3, "v3"))
+        self.sf.add(Record(1, "v1"))
+        self.sf.add(Record(2, "v2"))  # aquí debe ocurrir _merge_rebuild()
+        # Aux debe quedar vacía y main ordenado
+        self.assertEqual(len(self.sf.aux), 0)
+        keys = [r.key for r in self.sf.range_search(-999, 999)]
+        self.assertEqual(keys, [1, 2, 3])
+
+        # Luego una inserción extra queda en aux pero aún debe aparecer en search
+        self.sf.add(Record(4, "v4"))
+        vals = [r.value for r in self.sf.search(4)]
+        self.assertEqual(vals, ["v4"])
+
+    def test_range_search(self):
+        for k in [1, 4, 5, 7, 9]:
+            self.sf.add(Record(k, f"v{k}"))
+        res_keys = [r.key for r in self.sf.range_search(4, 7)]
+        self.assertEqual(res_keys, [4, 5, 7])
+
+    def test_edge_cases_range(self):
+        # vacío
+        self.assertEqual(self.sf.range_search(10, 20), [])
+        # un elemento
+        self.sf.add(Record(15, "v15"))
+        self.assertEqual([r.key for r in self.sf.range_search(10, 20)], [15])
+        # start > end => vacío
+        self.assertEqual(self.sf.range_search(20, 10), [])
+
+    def test_duplicates(self):
+        self.sf.add(Record(2, "a"))
+        self.sf.add(Record(2, "b"))
+        self.sf.add(Record(2, "c"))  # dispara rebuild
+        self.sf.add(Record(2, "d"))  # queda en aux
+        res = self.sf.search(2)
+        self.assertEqual(sorted([r.value for r in res]), ["a", "b", "c", "d"])
+        # range sobre el mismo valor debe traer los 4
+        res2 = self.sf.range_search(2, 2)
+        self.assertEqual(len(res2), 4)
+
+    def test_remove(self):
+        for k in [10, 20, 30]:
+            self.sf.add(Record(k, f"v{k}"))
+        removed = self.sf.remove(20)
+        self.assertTrue(removed)
+        self.assertEqual(self.sf.search(20), [])
+        self.assertEqual([r.key for r in self.sf.search(10)], [10])
+        self.assertEqual([r.key for r in self.sf.search(30)], [30])
+
+    def test_remove_nonexistent(self):
+        self.sf.add(Record(10, "v10"))
+        self.assertFalse(self.sf.remove(99))
+        self.assertEqual([r.key for r in self.sf.search(10)], [10])
+
+    def test_remove_then_insert_again(self):
+        self.sf.add(Record(10, "v10"))
+        self.sf.remove(10)
+        self.sf.add(Record(10, "v10b"))
+        res = self.sf.search(10)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0].value, "v10b")
+
+    def test_negative_numbers(self):
+        for k in [-10, -5, 0, 5, 10]:
+            self.sf.add(Record(k, f"v{k}"))
+        for k in [-10, -5, 0, 5, 10]:
+            self.assertEqual([r.key for r in self.sf.search(k)], [k])
+        res = self.sf.range_search(-7, 7)
+        self.assertEqual([r.key for r in res], [-5, 0, 5])
+
+    def test_sparse_index_exists_after_rebuild(self):
+        for k in [5, 1, 3]:
+            self.sf.add(Record(k, f"v{k}"))  # dispara rebuild
+        self.assertTrue(len(self.sf.sparse_index) > 0)
+        # primer marcador debe apuntar a la primera clave en main
+        first_key_idx, pos = self.sf.sparse_index[0]
+        self.assertEqual(first_key_idx, self.sf.main[pos].key)
+
+
+class TestSequentialFileIndexWrapper(unittest.TestCase):
+    def setUp(self):
+        self.idx = SequentialFileIndex(rebuild_threshold=3, index_block_size=2)
+
+    def test_wrapper_basic_insert_search(self):
+        self.idx.add_record(10, "v10")
+        self.idx.add_record(5, "v5")
+        res10 = self.idx.search(10)
+        self.assertEqual(len(res10), 1)
+        self.assertEqual((res10[0].key, res10[0].value), (10, "v10"))
+        self.assertEqual(self.idx.search(99), [])
+
+    def test_wrapper_multiple_and_ranges(self):
+        data = [50, 20, 80, 10, 30, 60, 90, 5, 15, 25, 35, 55, 65, 85, 95]
+        for k in data:
+            self.idx.add_record(k, f"v{k}")
+        # rango existente
+        res = self.idx.range_search(20, 35)
+        self.assertEqual([r.key for r in res], [20, 25, 30, 35])
+        # rango total
+        res_all = self.idx.range_search(5, 95)
+        self.assertEqual(sorted([r.key for r in res_all]), sorted(data))
+        # rango vacío
+        self.assertEqual(self.idx.range_search(26, 29), [])
+        # límites exactos
+        self.assertEqual([r.key for r in self.idx.range_search(50, 50)], [50])
+        self.assertEqual([r.key for r in self.idx.range_search(95, 95)], [95])
+
+    def test_wrapper_sequential_and_reverse_inserts(self):
+        # secuencial
+        self.idx = SequentialFileIndex(rebuild_threshold=3, index_block_size=2)
+        for k in range(1, 51):
+            self.idx.add_record(k, f"v{k}")
+        for k in range(1, 51):
+            self.assertEqual([r.key for r in self.idx.search(k)], [k])
+
+        # reversa
+        self.idx = SequentialFileIndex(rebuild_threshold=3, index_block_size=2)
+        for k in range(50, 0, -1):
+            self.idx.add_record(k, f"v{k}")
+        for k in range(1, 51):
+            self.assertEqual([r.key for r in self.idx.search(k)], [k])
+
+    def test_wrapper_remove_and_large_range(self):
+        for k in range(1, 21):
+            self.idx.add_record(k, f"v{k}")
+        for k in [5, 10, 15]:
+            self.idx.remove_record(k)
+        res = self.idx.range_search(1, 20)
+        self.assertEqual([r.key for r in res], [k for k in range(1, 21) if k not in [5, 10, 15]])
+
+    def test_wrapper_duplicates(self):
+        self.idx.add_record(7, "a")
+        self.idx.add_record(7, "b")
+        self.idx.add_record(7, "c")
+        vals = sorted([r.value for r in self.idx.search(7)])
+        self.assertEqual(vals, ["a", "b", "c"])
+
+    def test_wrapper_stress(self):
+        big = SequentialFileIndex(rebuild_threshold=32, index_block_size=16)
+        data = list(range(1, 1001))
+        for k in data:
+            big.add_record(k, f"v{k}")
+        # muestras aleatorias
+        for k in random.sample(data, 50):
+            res = big.search(k)
+            self.assertEqual(len(res), 1)
+            self.assertEqual((res[0].key, res[0].value), (k, f"v{k}"))
+        # rango grande
+        res = big.range_search(100, 900)
+        self.assertEqual(len(res), 801)
+        self.assertEqual([r.key for r in res], list(range(100, 901)))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Se agrega el indice Sequential File con el main ordenado, área auxiliar para inserciones (aux) y un índice disperso por bloques (sparse_index) para saltos eficientes.
Incluye SequentialFileIndex con add_record, search, range_search, remove_record, soporte de duplicados y reconstrucción automática al alcanzar el umbral configurable rebuild_threshold (por defecto 64), además de index_block_size (por defecto 128)